### PR TITLE
Move installations to requirements.txt file

### DIFF
--- a/CensusIncomePrediction.ipynb
+++ b/CensusIncomePrediction.ipynb
@@ -16,9 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install thirdai\n",
-    "!pip3 install pandas # We need Pandas in the utils module to convert downloaded datasets to CSV format\n",
-    "!pip3 install numpy # We use numpy to analyze UDT performance in this notebook"
+    "!pip3 install -r requirements.txt"
    ]
   },
   {
@@ -175,7 +173,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -189,9 +187,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.10"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
@@ -199,5 +196,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/FraudDetection.ipynb
+++ b/FraudDetection.ipynb
@@ -17,9 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install thirdai==0.5.1\n",
-    "!pip3 install pandas\n",
-    "!pip3 install numpy\n",
+    "!pip3 install -r requirements.txt\n",
     "!pip3 install kaggle"
    ]
   },
@@ -199,7 +197,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.9 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -213,9 +211,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.9"
+   "version": "3.9.10"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
@@ -223,5 +220,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/IntentClassification.ipynb
+++ b/IntentClassification.ipynb
@@ -16,9 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install thirdai\n",
-    "!pip3 install pandas # We need Pandas in the utils module to convert downloaded datasets to CSV format\n",
-    "!pip3 install numpy # We use numpy to analyze UDT performance in this notebook"
+    "!pip3 install -r requirements.txt"
    ]
   },
   {
@@ -162,7 +160,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -176,9 +174,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.10"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
@@ -186,5 +183,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/PersonalizedMovieRecommendations.ipynb
+++ b/PersonalizedMovieRecommendations.ipynb
@@ -16,9 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install thirdai\n",
-    "!pip3 install pandas # We need Pandas in the utils module to convert downloaded datasets to CSV format\n",
-    "!pip3 install numpy # We use numpy to analyze UDT performance in this notebook"
+    "!pip3 install -r requirements.txt"
    ]
   },
   {
@@ -209,7 +207,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -223,9 +221,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.10"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
@@ -233,5 +230,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/SentimentAnalysis.ipynb
+++ b/SentimentAnalysis.ipynb
@@ -15,9 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install thirdai\n",
-    "!pip3 install datasets\n",
-    "!pip3 install pandas"
+    "!pip3 install -r requirements.txt"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+thirdai
+datasets==2.6.1
+numpy==1.23.4
+pandas==1.5.1


### PR DESCRIPTION
This change consolidates common imports across demos into a single `requirements.txt` file to reduce duplication and make it easier to add new dependencies that will not break existing notebooks. 