### PR TITLE
Bump up version of huggingface datasets

### DIFF
--- a/QueryReformulation.ipynb
+++ b/QueryReformulation.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install datasets==2.6.1 \n",
+    "!pip3 install datasets==2.6.2 \n",
     "!pip3 install thirdai --upgrade"
    ]
   },

--- a/SentimentAnalysis.ipynb
+++ b/SentimentAnalysis.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "!pip3 install thirdai --upgrade\n",
-    "!pip3 install datasets==2.6.1 \n",
+    "!pip3 install datasets==2.6.2 \n",
     "\n",
     "import thirdai\n",
     "thirdai.licensing.activate(\"KVN9-JVRJ-FAAN-4UPE-KVXT-KV4F-LMWK-CM9E\")"


### PR DESCRIPTION
As mentioned in this [comment](https://github.com/huggingface/datasets/issues/5406#issue-1519140544), huggingface `datasets` version 2.6.1 breaks with some datasets. This change bumps up the version to the suggested patch version. 

Tested this locally and verified the notebook ran successfully. 